### PR TITLE
Remove tkinter requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ scipy >= 1.7.0
 
 openpyxl >= 3.0.0
 
-tkinter (included with most Python distributions)
+Tkinter must be available in your Python installation
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ scikit-learn>=1.0.0
 scipy>=1.7.0
 openpyxl>=3.0.0
 streamlit>=1.15.0
-tkinter


### PR DESCRIPTION
## Summary
- drop tkinter from requirements
- note that Tkinter must be available in Python

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687ad573b8248327ae61b59092bbe4eb