### PR TITLE
Fix bicluster tabs rendering

### DIFF
--- a/BCTool_GUI.py
+++ b/BCTool_GUI.py
@@ -171,10 +171,9 @@ def main():
         all_enrich = []
         alg_names = list(st.session_state["Biclusters"].keys())
         tabs = st.tabs(alg_names)
-        tab_map = dict(zip(alg_names, tabs))
 
-        for alg, bic_list in st.session_state["Biclusters"].items():
-            with tab_map[alg]:
+        for i, (alg, bic_list) in enumerate(st.session_state["Biclusters"].items()):
+            with tabs[i]:
                 st.header(alg)
                 st.write(summarize_biclusters(bic_list, gene_ids, alg))
 


### PR DESCRIPTION
## Summary
- ensure every algorithm's tab displays its biclusters

## Testing
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_6882622d45e48327aade5ab7ef9be9cb