### PR TITLE
Ensure file upload resets for multiple algorithm runs

### DIFF
--- a/BCTool_GUI.py
+++ b/BCTool_GUI.py
@@ -7,6 +7,11 @@ import adapter
 def uploaded_data(data):
     if data is None:
         return None, None
+    # Ensure file pointer is at the beginning for repeated reads
+    try:
+        data.seek(0)
+    except Exception:
+        pass
     suffix = data.name.split(".")[-1].lower()
     if suffix in {"csv", "tsv"}:
         df = pd.read_csv(data, sep="\t" if suffix == "tsv" else ",", index_col=0)


### PR DESCRIPTION
## Summary
- reset uploaded file position before parsing so each run reloads the matrix

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882622d45e48327aade5ab7ef9be9cb