### PR TITLE
Fix gene2go validation

### DIFF
--- a/GO_assessment.py
+++ b/GO_assessment.py
@@ -35,7 +35,15 @@ def ensure_uncompressed_g2g(path: Path) -> Path:
 
     target = path.with_suffix("")
     if target.exists():
-        return target
+        try:
+            with open(target) as fh:
+                first_line = fh.readline().strip()
+            if not first_line.startswith("version https://git-lfs.github.com/spec"):
+                return target
+            print("Ignoring git-lfs pointer for gene2go – extracting archive…")
+            target.unlink()
+        except OSError:
+            return target
     try:
         with gzip.open(path, "rt") as fin, open(target, "w") as fout:
             shutil.copyfileobj(fin, fout)


### PR DESCRIPTION
## Summary
- check if existing gene2go file is an LFS pointer
- extract archive if pointer is detected

## Testing
- `flake8`
- `pip install -r requirements.txt` *(runs before tests)*
- `python - GO_assessment.py ensure_uncompressed_g2g` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68842c1c13088327920d32fe7c4f8f9d